### PR TITLE
update gdc-client easyconfig to use PythonBundle easyblock

### DIFF
--- a/easybuild/easyconfigs/g/gdc-client/gdc-client-1.3.0-foss-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/g/gdc-client/gdc-client-1.3.0-foss-2018b-Python-2.7.15.eb
@@ -1,4 +1,4 @@
-easyblock = 'Bundle'
+easyblock = 'PythonBundle'
 
 name = 'gdc-client'
 version = '1.3.0'
@@ -10,14 +10,13 @@ description = """The gdc-client provides several convenience functions over the 
 
 toolchain = {'name': 'foss', 'version': '2018b'}
 
-# this is a bundle of Python packages
-exts_defaultclass = 'PythonPackage'
-
 dependencies = [
     ('Python', '2.7.15'),
     ('libxslt', '1.1.32'),
     ('libyaml', '0.2.1'),
 ]
+
+use_pip = True
 
 exts_list = [
     ('pyasn1', '0.2.3', {
@@ -120,11 +119,6 @@ exts_list = [
         'checksums': ['2a847f7498491fe69f86f163b9adc6ba752e740f5f17791da8c17a336a84751f'],
     }),
 ]
-
-modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
-
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
 
 sanity_check_paths = {
     'files': ['bin/gdc-client'],


### PR DESCRIPTION
@fizwit changes for https://github.com/easybuilders/easybuild-easyconfigs/pull/7090

For easyconfigs that bundle several Python packages, we now have a dedicated easyblock in `develop` that we would like to start adopting, see https://github.com/easybuilders/easybuild-easyblocks/pull/1553 .

As you can tell from the changes, this results in a cleaner easyconfig file.

I've also enabled to use of `pip` to install the Python packages, we hope to make this the default in EasyBuild v4.0.